### PR TITLE
Fixed a likely typo

### DIFF
--- a/lib/socket/datagram.ex
+++ b/lib/socket/datagram.ex
@@ -38,7 +38,7 @@ defmodule Socket.Datagram do
   use Socket.Helpers
 
   defdelegate send(self, packet, to), to: Socket.Datagram.Protocol
-  defbang send(self, packet, to), to: Socket.Stream.Protocol
+  defbang send(self, packet, to), to: Socket.Datagram.Protocol
 
   defdelegate recv(self), to: Socket.Datagram.Protocol
   defbang     recv(self), to: Socket.Datagram.Protocol


### PR DESCRIPTION
Sorry if I'm wrong here, since I'm not very experienced with Elixir, but it looks like Socket.Datagram.send! is calling a function in Socket.Stream.Protocol rather than Socket.Datagram.Protocol. Not a major issue, since Socket.Datagram.send (without the bang) is equivalent, but it's a little quirk that forced me to look up the implementation.
