### PR TITLE
Update example code so it compiles and works in Elixir v0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,35 +8,39 @@ Examples
 
 ```elixir
 defmodule HTTP do
+
   def get(uri) when is_binary(uri) or is_list(uri) do
     get(URI.parse(uri))
   end
 
-  def get(URI.Info[host: host, port: port, path: path]) do
-    sock = Socket.TCP.connect! host, port, packet: :line
-    sock |> Socket.Stream.send! "GET #{path || "/"} HTTP/1.1\r\nHost: #{host}\r\n\r\n"
+  def get(%URI{scheme: scheme, host: host, port: port, path: path, query: query}) do
+    sock = Socket.TCP.connect!(host, port, packet: :line)
+    sock |> Socket.Stream.send! "GET #{path || "/"}?#{query || ""} HTTP/1.1\r\nHost: #{host}\r\n\r\n"
 
-    [_, code, text] = Regex.run %r"HTTP/1.1 (.*?) (.*?)\s*$", sock |> Socket.Stream.recv!
+    [_, code, text] = Regex.run(~r{HTTP/1.1 (.*?) (.*?)\s*$}, sock |> Socket.Stream.recv!)
 
     headers = headers([], sock) |> Enum.into(%{})
 
     sock |> Socket.packet! :raw
-    body = sock |> Socket.Stream.recv!(binary_to_integer(headers["Content-Length"]))
 
-    { { binary_to_integer(code), text }, headers, body }
+    # NOTE : Will barf if site does not set Content-Length header.
+    body = sock |> Socket.Stream.recv!(String.to_integer(headers["Content-Length"]))
+
+    { { String.to_integer(code), text }, headers, body }
   end
 
-  defp headers(acc, sock) do
+  def headers(acc, sock) do
     case sock |> Socket.Stream.recv! do
       "\r\n" ->
         acc
 
       line ->
-        [_, name, value] = Regex.run %r/^(.*?):\s*(.*?)\s*$/, line
+        [_, name, value] = Regex.run(~r/^(.*?):\s*(.*?)\s*$/, line)
 
         headers([{ name, value } | acc], sock)
     end
   end
+
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ defmodule HTTP do
     { { String.to_integer(code), text }, headers, body }
   end
 
-  def headers(acc, sock) do
+  defp headers(acc, sock) do
     case sock |> Socket.Stream.recv! do
       "\r\n" ->
         acc


### PR DESCRIPTION
Also adds rudimentary handling of query string params.  Note that if the remote site does not return a Content-Length header then line 27 will explode (e.g. with URL http://www.cnn.com/). I have not addressed that pre-existing issue.