### PR TITLE
Return the error code if http handshake fails in Socket.Web.connect

### DIFF
--- a/lib/socket/web.ex
+++ b/lib/socket/web.ex
@@ -155,8 +155,11 @@ defmodule Socket.Web do
     try do
       { :ok, connect!(address, port, options) }
     rescue
-      MatchError ->
-        { :error, "malformed handshake" }
+      e in [MatchError] ->
+        case e.term do
+          { :http_response, _, http_code, http_message } -> { :error, { http_code, http_message } }
+          _ -> { :error, "malformed handshake" }
+        end
 
       e in [RuntimeError] ->
         { :error, e.message }


### PR DESCRIPTION
Currently if I want to know why a websocket handshake fails (ie the http code the server returns) I have to use `Socket.Web.connect!` and rescue MatchError in my app, since the non-bang `connect` function just gives `{:error, "malformed handshake"}` for all MatchErrors.

Would be nice to avoid having to do that, so this'd include the http code and message in the error tuple (eg `{:error, {401, "Unauthorized"}}`) if it can get them.