### PR TITLE
headers["upgrade"] on websocket server

### DIFF
--- a/lib/socket/web.ex
+++ b/lib/socket/web.ex
@@ -412,7 +412,7 @@ defmodule Socket.Web do
 
     headers = headers(%{}, client)
 
-    if headers["upgrade"] != "websocket" or headers["connection"] != "Upgrade" do
+    if headers["upgrade"] != "websocket" and headers["connection"] != "Upgrade" do
       client |> Socket.close
 
       raise RuntimeError, message: "malformed upgrade request"


### PR DESCRIPTION
browsers dont seem to send these 2 headers together, causing it to refuse valid conns at handshake (tested last firefox & chrome)
 if headers["upgrade"] != "websocket" and headers["connection"] != "Upgrade" do