### PR TITLE
Fixing tiny typo in spec

### DIFF
--- a/lib/socket/udp.ex
+++ b/lib/socket/udp.ex
@@ -85,7 +85,7 @@ defmodule Socket.UDP do
   Create a UDP socket listening on the given port and using the given options,
   raising if an error occurs.
   """
-  @spec open!(:ient.port_number, Keyword.t) :: t | no_return
+  @spec open!(:inet.port_number, Keyword.t) :: t | no_return
   defbang open(port, options)
 
   @doc """


### PR DESCRIPTION
Should be :inet.port_number