### PR TITLE
Fix `recv` when length is zero in `Socket.Web`

### DIFF
--- a/lib/socket/web.ex
+++ b/lib/socket/web.ex
@@ -568,31 +568,36 @@ defmodule Socket.Web do
       { :error, _ } = error ->
         error
 
-      0 ->
-        { :ok, "" }
-
       length ->
         if mask do
           case socket |> Socket.Stream.recv(4, options) do
             { :ok, << key :: 32 >> } ->
-              case socket |> Socket.Stream.recv(length, options) do
-                { :ok, data } ->
-                  { :ok, unmask(key, data) }
+              if length > 0 do
+                case socket |> Socket.Stream.recv(length, options) do
+                  { :ok, data } ->
+                    { :ok, unmask(key, data) }
 
-                { :error, _ } = error ->
-                  error
+                  { :error, _ } = error ->
+                    error
+                end
+              else
+                { :ok, "" }
               end
 
             { :error, _ } = error ->
               error
           end
         else
-          case socket |> Socket.Stream.recv(length, options) do
-            { :ok, data } ->
-              { :ok, data }
+          if length > 0 do
+            case socket |> Socket.Stream.recv(length, options) do
+              { :ok, data } ->
+                { :ok, data }
 
-            { :error, _ } = error ->
-              error
+              { :error, _ } = error ->
+                error
+            end
+          else
+            { :ok, "" }
           end
         end
     end


### PR DESCRIPTION
For `:gen_tcp.recv/3` and `:ssl.recv/3` functions, when receiving a length 0,
will both try to fetch all available bytes, which is not suitable for
websocket case.

Eg. when the server sends a ping with no payload, we should not try to
fetch bytes from the server. Instead, we should respond with `pong`
as soon as possible. (of course, the responding thing is the job
of `elixir-socket` user)

Also, when reading the codes, I found a potential bug for calling
`forge` function. Before, if `options[:mask] = nil`, it will never
be passed to `forge` function with `options[:mask] || mask` clause.

cc @meh 