### PR TITLE
Distinguish case when websocket abruptly closes with no close frame

### DIFF
--- a/lib/socket/web.ex
+++ b/lib/socket/web.ex
@@ -686,6 +686,11 @@ defmodule Socket.Web do
           end
         end |> on_success(options)
 
+      { :ok, nil} ->
+        # 1006 is reserved for connection closed with no close frame
+        # https://tools.ietf.org/html/rfc6455#section-7.4.1
+        { :ok, { :close, close_code(1006), nil } }
+
       { :ok, _ } ->
         { :error, :protocol_error }
 


### PR DESCRIPTION
Currently, if a websocket connection abruptly terminates with no close frame, the library gives `{ :error, :protocol_error }`. (More specifically: Socket.Stream#recv converts `{ :error, :closed }` to `{ :ok, nil }`, which then in Socket.Web#recv falls under the catchall `{ :ok, _ } -> { :error, :protocol_error }`.

It would be nice to be able to distinguish abnormal closes from other protocol errors. [The rfc reserves code 1006 for this](https://tools.ietf.org/html/rfc6455#section-7.4.1) - "*for use in applications expecting a status code to indicate that the connection was closed abnormally, e.g., without sending or receiving a Close control frame*". (The `close_code` helper already includes it, though currently it's never used as it would be illegal for a server to actually set that as a close code).

So this PR maps `{:ok, nil}` to `{ :ok, { :close, close_code(1006), nil } }`, to match what you get with all the other close codes.