### PR TITLE
Fix crash on release start

### DIFF
--- a/lib/socket.ex
+++ b/lib/socket.ex
@@ -258,8 +258,6 @@ defmodule Socket do
   defdelegate close(self), to: Socket.Protocol
   defbang close(self), to: Socket.Protocol
 
-  @on_load :uris
-
   @doc false
   def uris do
     URI.default_port "ws", 80

--- a/lib/socket/app.ex
+++ b/lib/socket/app.ex
@@ -1,0 +1,8 @@
+defmodule Socket.App do
+  use Application
+
+  def start(_type, _args) do
+    Socket.uris
+    {:ok, self}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,8 @@ defmodule Socket.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [ applications: [:crypto, :ssl] ]
+    [ applications: [:crypto, :ssl, :elixir],
+      mod: {Socket.App, []} ]
   end
 
   defp deps do


### PR DESCRIPTION
Because loading of a module in a normal release
happing before starting of application, this application
assumed, that elixir application is started.
Moving actions from on_load to start of
application, ensuring the dependencies.