### PR TITLE
web: fix Socket.Error exceptions

### DIFF
--- a/lib/socket/web.ex
+++ b/lib/socket/web.ex
@@ -712,7 +712,7 @@ defmodule Socket.Web do
         raise RuntimeError, message: "protocol error"
 
       { :error, code } ->
-        raise Socket.Error, code: code
+        raise Socket.Error, reason: code
     end
   end
 
@@ -804,7 +804,7 @@ defmodule Socket.Web do
         :ok
 
       { :error, code } ->
-        raise Socket.Error, code: code
+        raise Socket.Error, reason: code
     end
   end
 


### PR DESCRIPTION
`recv!` / `send!` would try to raise `Socket.Error`
with `:code` keyword, but it expected `:reason`.

The effect of that was this confusing error:
```
18:27:04.341 [error] Process #PID<0.468.0> raised an exception
** (FunctionClauseError) no function clause matching in Socket.Error.exception/1
    lib/socket.ex:18: Socket.Error.exception([code: :ebadf])
    lib/socket/web.ex:715: Socket.Web.recv!/2
```

Which with this commit changes to:
```
18:28:23.947 [error] Process #PID<0.469.0> raised an exception
** (Socket.Error) bad file number
    lib/socket/web.ex:715: Socket.Web.recv!/2
```

revealing the actual error.