### PR TITLE
Fix "malformed upgrade response" detection

### DIFF
--- a/lib/socket/web.ex
+++ b/lib/socket/web.ex
@@ -246,8 +246,8 @@ defmodule Socket.Web do
     { :http_response, _, 101, _ } = client |> Socket.Stream.recv!(options)
     headers                       = headers(%{}, client, options)
 
-    if String.downcase(headers["upgrade"]) != "websocket" or
-       String.downcase(headers["connection"]) != "upgrade" do
+    if !headers["upgrade"] or String.downcase(headers["upgrade"]) != "websocket" or
+       !headers["connection"] or String.downcase(headers["connection"]) != "upgrade" do
       client |> Socket.close
 
       raise RuntimeError, message: "malformed upgrade response"


### PR DESCRIPTION
When the `header` did not contain the `upgrade` or `connection` elements the code did crush trying to `String.downcase` a `nil` value.

The error message returned:
```
** (FunctionClauseError) no function clause matching in String.Casing.downcase/2
    (elixir) unicode/unicode.ex:313: String.Casing.downcase(nil, "")
    (socket) lib/socket/web.ex:249: Socket.Web.connect!/3
```