### PR TITLE
Force accept! to return socket

### DIFF
--- a/lib/socket/web.ex
+++ b/lib/socket/web.ex
@@ -474,6 +474,7 @@ defmodule Socket.Web do
       if(extensions, do: ["Sec-WebSocket-Extensions: ", Enum.join(extensions, ", "), "\r\n"], else: []),
       if(protocol, do: ["Sec-WebSocket-Protocol: ", protocol, "\r\n"], else: []),
       "\r\n" ])
+    socket
   end
 
   @doc """


### PR DESCRIPTION
The spec for `accept!` is: `accept!(t, Keyword.t) :: t | no_return`  
However, on the definition for `accept!` that matches for finalizing client acception, the result of `send!` will be returned, which is `:ok`, not `t | no_return`