### PR TITLE
Use the correct key when passing down cacerts

### DIFF
--- a/lib/socket/ssl.ex
+++ b/lib/socket/ssl.ex
@@ -387,7 +387,7 @@ defmodule Socket.SSL do
         [{ :cacertfile, path }]
 
       { :authorities, ca } ->
-        [{ :cacert, ca }]
+        [{ :cacerts, ca }]
 
       { :dh, [path: path] } ->
         [{ :dhfile, path }]


### PR DESCRIPTION
Hey there,

Thanks for maintaining this library. While I was implementing custom SSL protected TCP connections I noticed this little 🐛 .

According to http://erlang.org/doc/man/ssl.html passing down encoded SSL
authorities to erlang ssl requires the key `cacerts`.

cheers,