### PR TITLE
Fix accept, it should pass it all to accept!

### DIFF
--- a/lib/socket/web.ex
+++ b/lib/socket/web.ex
@@ -385,7 +385,7 @@ defmodule Socket.Web do
   connect based on Origin header, path and other things.
   """
   @spec accept(t, Keyword.t) :: { :ok, t } | { :error, error }
-  def accept(%W{key: nil} = self, options \\ []) do
+  def accept(self, options \\ []) do
     try do
       { :ok, accept!(self, options) }
     rescue


### PR DESCRIPTION
```elixir
{:ok, server} = Socket.Web.listen(4040)
{:ok, client} = Socket.Web.accept(server)
{:ok, _} = Socket.Web.accept(client)
```
That gives me a `function_clause` error, because the client returned by `Socket.Web.accept(server)` does have a `key`.

`accept` should not pattern match against `key: nil`, but simply pass it to `accept!`. This PR fixes that.